### PR TITLE
Pin structlog to 15.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version='0.1.0',
     py_modules=['wrapplog'],
     install_requires=[
-        'structlog',
+        'structlog==15.0.0',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
wrapplog seems to be using some internal magic in structlog, that
structlog has gotten rid of as of 16.0.0. We should avoid relying on
structlogs internal magic, but for the time being we can quickly round
the problem by just using an older version.
