### PR TITLE
Add metadata to wrapplog

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In [1]: import wrapplog
 In [2]: log = wrapplog.Logger()
 
 In [3]: log.info('hello', name='Jane')
-INFO {"level": "info", "msg": "hello", "name": "Jane", "namespace": "__main__"}
+INFO {"level": "info", "msg": "hello", "name": "Jane", "service": None, "host":None, "namespace": "__main__"}
 
 In [4]: class MyClass(object):
    ...:     log = wrapplog.Logger()
@@ -23,7 +23,7 @@ In [4]: class MyClass(object):
    ...:
 
 In [5]: MyClass().hello('Jane')
-WARNING {"level": "warning", "msg": "HELLO", "name": "Jane", "namespace": "__main__.MyClass"}
+WARNING {"level": "warning", "msg": "HELLO", "name": "Jane", "service": None, "host":None, "namespace": "__main__.MyClass"}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,29 +5,58 @@ Changes to structlog to work according to WEP 007:
 
 * Outputs JSON
 * Drop support for critical log level
-* `event` key renamed to `msg`
 * Add automatic namespace generation for Loggers similar to twisted.logger
 
 ```python
 
 In [1]: import wrapplog
 
-In [2]: wrapplog.start_logging()
+In [2]: log = wrapplog.Logger()
 
-In [3]: log = wrapplog.Logger()
-
-In [4]: log.info('hello', name='Jane')
+In [3]: log.info('hello', name='Jane')
 INFO {"level": "info", "msg": "hello", "name": "Jane", "namespace": "__main__"}
 
-In [5]: class MyClass(object):
+In [4]: class MyClass(object):
    ...:     log = wrapplog.Logger()
    ...:     def hello(self, name):
    ...:         self.log.warning('HELLO', name=name)
    ...:
 
-In [6]: MyClass().hello('Jane')
+In [5]: MyClass().hello('Jane')
 WARNING {"level": "warning", "msg": "HELLO", "name": "Jane", "namespace": "__main__.MyClass"}
 
 ```
+
+Logging event data
+==================
+
+**EVENT:**
+A level similar to `info`, but with a consistent *format* for a specific *behavior*, i.e. to log events apart from arbitrary information. This format would be of the following form where event data would be included in the `data` field:
+
+```json
+EVENT {"level": "event", "event": "user_created", "data": {"user": {"name": "jude", "id": 1}}, "host": "host-01", "namespace": "tests", "service": "api", "timestamp": "2017-03-08T12:34:59Z"}
+```
+
+```python
+
+In [1]: import wrapplog
+In [2]: log = wrapplog.Logger()
+In [3]: log.event('user_created', {"user": {"name": "jude", "id": 1}})
+```
+
+**METRIC:**
+For things you need to measure, you can log those instruments with a number value.
+
+```json
+METRIC {"level": "metric", "metric": "offers.deployed", "host": "host-01", "namespace": "tests", "service": "api", "timestamp": "2017-03-08T12:34:59Z", "value": 1}
+```
+
+```python
+
+In [1]: import wrapplog
+In [2]: log = wrapplog.Logger()
+In [3]: log.metric('offers.deployed', value=1)
+```
+
 
 License: MIT

--- a/README.md
+++ b/README.md
@@ -27,36 +27,4 @@ WARNING {"level": "warning", "msg": "HELLO", "name": "Jane", "service": None, "h
 
 ```
 
-Logging event data
-==================
-
-**EVENT:**
-A level similar to `info`, but with a consistent *format* for a specific *behavior*, i.e. to log events apart from arbitrary information. This format would be of the following form where event data would be included in the `data` field:
-
-```json
-EVENT {"level": "event", "event": "user_created", "data": {"user": {"name": "jude", "id": 1}}, "host": "host-01", "namespace": "tests", "service": "api", "timestamp": "2017-03-08T12:34:59Z"}
-```
-
-```python
-
-In [1]: import wrapplog
-In [2]: log = wrapplog.Logger()
-In [3]: log.event('user_created', {"user": {"name": "jude", "id": 1}})
-```
-
-**METRIC:**
-For things you need to measure, you can log those instruments with a number value.
-
-```json
-METRIC {"level": "metric", "metric": "offers.deployed", "host": "host-01", "namespace": "tests", "service": "api", "timestamp": "2017-03-08T12:34:59Z", "value": 1}
-```
-
-```python
-
-In [1]: import wrapplog
-In [2]: log = wrapplog.Logger()
-In [3]: log.metric('offers.deployed', value=1)
-```
-
-
 License: MIT

--- a/tests.py
+++ b/tests.py
@@ -17,6 +17,7 @@ class TestWrappObserver(object):
         self.service = "api"
         self.host = "host-01"
         self.namespace = 'tests'
+        self.metric_value = 10
         self.event_data = {"user": {"name": "jude", "id": 1}}
         self.log = Logger(self.out, service=self.service, host=self.host)
 
@@ -31,6 +32,8 @@ class TestWrappObserver(object):
         res['namespace'] = self.namespace
         res['service'] = self.service
         res['timestamp'] = self.timestamp
+        if level == 'metric':
+            res['value'] = self.metric_value
         return '%s %s\n' % (level.upper(), json.dumps(res))
 
     def test_debug(self):
@@ -50,8 +53,12 @@ class TestWrappObserver(object):
         self.assert_output(self._generate_output('error'))
 
     def test_event(self):
-        self.log.event(self.msg, data=self.event_data)
+        self.log.event(self.msg, self.event_data)
         self.assert_output(self._generate_output('event'))
+
+    def test_metric(self):
+        self.log.metric(self.msg, self.metric_value)
+        self.assert_output(self._generate_output('metric'))
 
     def get_output(self):
         self.out.seek(0)

--- a/tests.py
+++ b/tests.py
@@ -1,27 +1,33 @@
+from mock import patch
+from datetime import datetime
 from cStringIO import StringIO
-from wrapplog import Logger, start_logging
+
+from wrapplog import Logger
 
 
 class TestWrappObserver(object):
-    def setup(self):
+    @patch('wrapplog._timestamp')
+    def setup(self, timestamp_mock):
+        self.timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp_mock.return_value = self.timestamp
         self.out = StringIO()
         self.log = Logger(self.out)
 
     def test_debug(self):
         self.log.debug('Hello!')
-        self.assert_output('DEBUG {"level": "debug", "msg": "Hello!", "namespace": "tests"}\n')
+        self.assert_output('DEBUG {"level": "debug", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
 
     def test_info(self):
         self.log.info('Hello!')
-        self.assert_output('INFO {"level": "info", "msg": "Hello!", "namespace": "tests"}\n')
+        self.assert_output('INFO {"level": "info", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
 
     def test_warning(self):
         self.log.warning('Hello!')
-        self.assert_output('WARNING {"level": "warning", "msg": "Hello!", "namespace": "tests"}\n')
+        self.assert_output('WARNING {"level": "warning", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
 
     def test_error(self):
         self.log.error('Hello!')
-        self.assert_output('ERROR {"level": "error", "msg": "Hello!", "namespace": "tests"}\n')
+        self.assert_output('ERROR {"level": "error", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
 
     def get_output(self):
         self.out.seek(0)

--- a/tests.py
+++ b/tests.py
@@ -2,12 +2,10 @@ from cStringIO import StringIO
 from wrapplog import Logger, start_logging
 
 
-
 class TestWrappObserver(object):
     def setup(self):
         self.out = StringIO()
-        start_logging(self.out)
-        self.log = Logger()
+        self.log = Logger(self.out)
 
     def test_debug(self):
         self.log.debug('Hello!')
@@ -26,7 +24,7 @@ class TestWrappObserver(object):
         self.assert_output('ERROR {"level": "error", "msg": "Hello!", "namespace": "tests"}\n')
 
     def get_output(self):
-        self.out.reset()
+        self.out.seek(0)
         return self.out.read()
 
     def assert_output(self, expected):

--- a/tests.py
+++ b/tests.py
@@ -17,12 +17,16 @@ class TestWrappObserver(object):
         self.service = "api"
         self.host = "host-01"
         self.namespace = 'tests'
+        self.event_data = {"user": {"name": "jude", "id": 1}}
         self.log = Logger(self.out, service=self.service, host=self.host)
 
     def _generate_output(self, level):
         res = collections.OrderedDict()
         res['level'] = level
         res['msg'] = self.msg
+        if level == 'event':
+            res['data'] = self.event_data
+
         res['host'] = self.host
         res['namespace'] = self.namespace
         res['service'] = self.service
@@ -44,6 +48,10 @@ class TestWrappObserver(object):
     def test_error(self):
         self.log.error(self.msg)
         self.assert_output(self._generate_output('error'))
+
+    def test_event(self):
+        self.log.event(self.msg, data=self.event_data)
+        self.assert_output(self._generate_output('event'))
 
     def get_output(self):
         self.out.seek(0)

--- a/tests.py
+++ b/tests.py
@@ -17,59 +17,17 @@ class TestWrappObserver(object):
         self.service = "api"
         self.host = "host-01"
         self.namespace = 'tests'
-        self.metric_value = 10
-        self.event_data = {"user": {"name": "jude", "id": 1}}
         self.log = Logger(self.out, service=self.service, host=self.host)
 
     def _generate_output(self, level):
-        ''' Outputs the fields in an ordered way as per test expectations
-        Order is the following:
-        - level
-        - msg (For all log levels apart from 'metric' and 'event')
-        - event (Applicable for 'event' level)
-        - metric (Applicable for 'metric' level)
-        - all other fields are ordered in alphabetical order
-        - namespace is not applicable to 'event' and 'metric' level
-        '''
-        def generate_event_output():
-            res = collections.OrderedDict()
-            res['level'] = level
-            res['event'] = self.msg
-            res['data'] = self.event_data
-            res['host'] = self.host
-            res['service'] = self.service
-            res['timestamp'] = self.timestamp
-            return res
-
-        def generate_metric_output():
-            res = collections.OrderedDict()
-            res['level'] = level
-            res['metric'] = self.msg
-            res['host'] = self.host
-            res['service'] = self.service
-            res['timestamp'] = self.timestamp
-            res['value'] = self.metric_value
-            return res
-
-        def generate_default_output():
-            ''' Applies to all other log levels apart from event and metric '''
-            res = collections.OrderedDict()
-            res['level'] = level
-            res['msg'] = self.msg
-            res['host'] = self.host
-            res['namespace'] = self.namespace
-            res['service'] = self.service
-            res['timestamp'] = self.timestamp
-            return res
-
-        output_dict = {}
-        if level == 'event':
-            output_dict = generate_event_output()
-        elif level == 'metric':
-            output_dict = generate_metric_output()
-        else:
-            output_dict = generate_default_output()
-        return '%s %s\n' % (level.upper(), json.dumps(output_dict))
+        res = collections.OrderedDict()
+        res['level'] = level
+        res['msg'] = self.msg
+        res['host'] = self.host
+        res['namespace'] = self.namespace
+        res['service'] = self.service
+        res['timestamp'] = self.timestamp
+        return '%s %s\n' % (level.upper(), json.dumps(res))
 
     def test_debug(self):
         self.log.debug(self.msg)
@@ -86,14 +44,6 @@ class TestWrappObserver(object):
     def test_error(self):
         self.log.error(self.msg)
         self.assert_output(self._generate_output('error'))
-
-    def test_event(self):
-        self.log.event(self.msg, self.event_data)
-        self.assert_output(self._generate_output('event'))
-
-    def test_metric(self):
-        self.log.metric(self.msg, self.metric_value)
-        self.assert_output(self._generate_output('metric'))
 
     def get_output(self):
         self.out.seek(0)

--- a/tests.py
+++ b/tests.py
@@ -24,10 +24,13 @@ class TestWrappObserver(object):
     def _generate_output(self, level):
         res = collections.OrderedDict()
         res['level'] = level
-        res['msg'] = self.msg
+        if level in ['event', 'metric']:
+            res[level] = self.msg
+        else:
+            res['msg'] = self.msg
+
         if level == 'event':
             res['data'] = self.event_data
-
         res['host'] = self.host
         res['namespace'] = self.namespace
         res['service'] = self.service

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+import json
+import collections
 from mock import patch
 from datetime import datetime
 from cStringIO import StringIO
@@ -11,23 +13,37 @@ class TestWrappObserver(object):
         self.timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         timestamp_mock.return_value = self.timestamp
         self.out = StringIO()
-        self.log = Logger(self.out)
+        self.msg = 'Hello'
+        self.service = "api"
+        self.host = "host-01"
+        self.namespace = 'tests'
+        self.log = Logger(self.out, service=self.service, host=self.host)
+
+    def _generate_output(self, level):
+        res = collections.OrderedDict()
+        res['level'] = level
+        res['msg'] = self.msg
+        res['host'] = self.host
+        res['namespace'] = self.namespace
+        res['service'] = self.service
+        res['timestamp'] = self.timestamp
+        return '%s %s\n' % (level.upper(), json.dumps(res))
 
     def test_debug(self):
-        self.log.debug('Hello!')
-        self.assert_output('DEBUG {"level": "debug", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
+        self.log.debug(self.msg)
+        self.assert_output(self._generate_output('debug'))
 
     def test_info(self):
-        self.log.info('Hello!')
-        self.assert_output('INFO {"level": "info", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
+        self.log.info(self.msg)
+        self.assert_output(self._generate_output('info'))
 
     def test_warning(self):
-        self.log.warning('Hello!')
-        self.assert_output('WARNING {"level": "warning", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
+        self.log.warning(self.msg)
+        self.assert_output(self._generate_output('warning'))
 
     def test_error(self):
-        self.log.error('Hello!')
-        self.assert_output('ERROR {"level": "error", "msg": "Hello!", "namespace": "tests", "timestamp": "%s"}\n' % self.timestamp)
+        self.log.error(self.msg)
+        self.assert_output(self._generate_output('error'))
 
     def get_output(self):
         self.out.seek(0)

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -90,15 +90,16 @@ class Logger(object):
     def error(self, *args, **kwargs):
         return self._log.error(*args, **kwargs)
 
-    def event(self, name, data):
+    def event(self, name, data=None):
         """Logs an event.
 
         :param name: Name of the event
         :param data: Dictionary holding data to describe the event
         """
+        data = data or {}
         return self._log.event(name, data=data)
 
-    def metric(self, name, value):
+    def metric(self, name, value=1):
         """Logs a metric.
 
         :param name: Name of the metric

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -17,7 +17,9 @@ def start_logging(output=None):
 
 
 class Logger(object):
-    def __init__(self, output=None, namespace=None, source=None):
+    def __init__(self, output=None,
+                 namespace=None, source=None,
+                 service=None, host=None):
         log = wrap_logger(
                         PrintLogger(output),
                         processors=[
@@ -34,6 +36,14 @@ class Logger(object):
             except:
                 namespace = 'unknown'
         self._log = log.bind(namespace=namespace)
+
+        service = service or os.environ.get('SERVICE_NAME')
+        if service:
+            self._log = self._log.bind(service=service)
+
+        host = host or os.environ.get('HOSTNAME')
+        if host:
+            self._log = self._log.bind(host=host)
 
     def __get__(self, oself, type=None):
         if oself is None:

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -119,7 +119,11 @@ def add_timestamp(_, __, event_dict):
 def order_fields(_, level, event_dict):
     res = collections.OrderedDict()
     res['level'] = level
-    res['msg'] = event_dict.pop('event')
+    key = "msg"
+    if level in ["event", "metric"]:
+        key = level
+
+    res[key] = event_dict.pop('event')
     res.update(sorted(event_dict.items()))
     return res
 

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -124,5 +124,5 @@ def order_fields(_, level, event_dict):
     return res
 
 
-def render_wrapp_log(_, level, event_dict):
-    return level.upper() + ' ' + event_dict
+def render_wrapp_log(_, level, event_str):
+    return level.upper() + ' ' + event_str

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import structlog
 from structlog.processors import JSONRenderer
-from structlog import wrap_logger, BoundLogger, PrintLogger, PrintLoggerFactory
+from structlog import wrap_logger, PrintLogger, PrintLoggerFactory
 
 
 # Deprecated
@@ -14,36 +14,12 @@ def start_logging(output=None):
     return
 
 
-class NumberValueError(Exception):
-    pass
-
-
-class WrappPrintLogger(PrintLogger):
-    def msg(self, message):
-        return super(WrappPrintLogger, self).msg(message)
-
-    event = metric = msg
-
-
-class WrappLogger(BoundLogger):
-    def event(self, name, data=None):
-        return super(WrappLogger, self)._proxy_to_logger('event', name, data=data)
-
-    def metric(self, name, value=1):
-        try:
-            float(value)
-        except ValueError:
-            raise NumberValueError(value)
-        return super(WrappLogger, self)._proxy_to_logger('metric', name, value=value)
-
-
 class Logger(object):
     def __init__(self, output=None,
                  namespace=None, source=None,
                  service=None, host=None):
         log = wrap_logger(
-                        WrappPrintLogger(output),
-                        wrapper_class=WrappLogger,
+                        PrintLogger(output),
                         processors=[
                             add_timestamp,
                             order_fields,
@@ -88,23 +64,6 @@ class Logger(object):
     def error(self, *args, **kwargs):
         return self._log.error(*args, **kwargs)
 
-    def event(self, name, data=None):
-        """Logs an event.
-
-        :param name: Name of the event
-        :param data: Dictionary holding data to describe the event
-        """
-        data = data or {}
-        return self._log.event(name, data=data)
-
-    def metric(self, name, value=1):
-        """Logs a metric.
-
-        :param name: Name of the metric
-        :param value: A number holding the value of the metric
-        """
-        return self._log.metric(name, value=value)
-
 
 def _timestamp():
     return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -118,15 +77,7 @@ def add_timestamp(_, __, event_dict):
 def order_fields(_, level, event_dict):
     res = collections.OrderedDict()
     res['level'] = level
-    # Levels 'event' and 'metric', don't require 'namespace' and 'msg' fields.
-    # Instead, they would require the fields 'event' and 'metric'
-    # respectively for the name of the event and metric.
-    if level in ["event", "metric"]:
-        event_dict.pop('namespace')
-        key = level
-    else:
-        key = "msg"
-    res[key] = event_dict.pop('event')
+    res["msg"] = event_dict.pop('event')
     res.update(sorted(event_dict.items()))
     return res
 

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -120,10 +120,14 @@ def add_timestamp(_, __, event_dict):
 def order_fields(_, level, event_dict):
     res = collections.OrderedDict()
     res['level'] = level
-    key = "msg"
+    # Levels 'event' and 'metric', don't require 'namespace' and 'msg' fields.
+    # Instead, they would require the fields 'event' and 'metric'
+    # respectively for the name of the event and metric.
     if level in ["event", "metric"]:
+        event_dict.pop('namespace')
         key = level
-
+    else:
+        key = "msg"
     res[key] = event_dict.pop('event')
     res.update(sorted(event_dict.items()))
     return res

--- a/wrapplog.py
+++ b/wrapplog.py
@@ -60,12 +60,10 @@ class Logger(object):
         self._log = log.bind(namespace=namespace)
 
         service = service or os.environ.get('SERVICE_NAME')
-        if service:
-            self._log = self._log.bind(service=service)
+        self._log = self._log.bind(service=service)
 
         host = host or os.environ.get('HOSTNAME')
-        if host:
-            self._log = self._log.bind(host=host)
+        self._log = self._log.bind(host=host)
 
     def __get__(self, oself, type=None):
         if oself is None:


### PR DESCRIPTION
This PR extends Wrapp's logging library to also log events and metrics. These are explained below:

**EVENT:**
Something similar to `info`, but with a consistent format for a specific behaviour, i.e. to log events apart from arbitrary information. This format would be of the following form:

```json
EVENT {"level": "event", "event": "user_created", "data": {"user": {"name": "jude", "id": 1}}, "host": "host-01", "namespace": "tests", "service": "api", "timestamp": "2017-03-08T12:34:59Z"}
```


**METRIC:**
For things you need to measure, you can log those instruments with a number value.

```json
METRIC {"level": "metric", "metric": "offers.deployed", "host": "host-01", "namespace": "tests", "service": "api", "timestamp": "2017-03-08T12:34:59Z", "value": 1}
```

Both EVENTs and METRICs would be used for monitoring so you can use the same library to profile your service and allow it to be ingested into tools like Sumo/ Librato for better visualization and monitoring.


**UPDATED: MAR 04, 2017**

- We decided to remove *event* and *metric* levels and leverage *info* for this purpose.
- The PR is then only left with refactorings, and adding more metadata to the log which would include *service*, *host* and *timestamp*.